### PR TITLE
Problem #16 Fix for flash-attn in open-r1-intuitor

### DIFF
--- a/open-r1-intuitor/Makefile
+++ b/open-r1-intuitor/Makefile
@@ -12,7 +12,7 @@ install:
 	. openr1/bin/activate && uv pip install --upgrade pip && \
 	uv pip install vllm==0.8.4 && \
 	uv pip install setuptools && \
-	uv pip install flash-attn --no-build-isolation && \
+	uv pip install flash-attn==2.7.4.post1 --no-build-isolation && \
 	GIT_LFS_SKIP_SMUDGE=1 uv pip install -e ".[dev]"
 
 style:

--- a/open-r1-intuitor/README.md
+++ b/open-r1-intuitor/README.md
@@ -66,11 +66,11 @@ uv venv openr1 --python 3.11 && source openr1/bin/activate && uv pip install --u
 > [!TIP]
 > For Hugging Face cluster users, add `export UV_LINK_MODE=copy` to your `.bashrc` to suppress cache warnings from `uv`
 
-Next, install vLLM and FlashAttention:
+Next, install vLLM and FlashAttention (use Flash Attention `v2.7.4.post1` to avoid ABI mismatches):
 
 ```shell
 uv pip install vllm==0.8.4
-uv pip install setuptools && uv pip install flash-attn --no-build-isolation
+uv pip install setuptools && uv pip install flash-attn==2.7.4.post1 --no-build-isolation
 ```
 
 This will also install PyTorch `v2.6.0` and it is **very important** to use this version since the vLLM binaries are compiled for it. You can then install the remaining dependencies for your specific use case via `pip install -e .[LIST OF MODES]`. For most contributors, we recommend:


### PR DESCRIPTION
Fixes problem with new flash-attn models having ABI conflictions in open-r1-intuitor, version locks flash-attn to a known working version. Same fix has been proposed to the original open-r1 model.

**I compiled and ran successfully on this version.**

Link to intuitor issue: https://github.com/sunblaze-ucb/Intuitor/issues/16
Link to openr1-issue: https://github.com/huggingface/open-r1/issues/684